### PR TITLE
Tests Unitaires - Bills - NewBillBtn

### DIFF
--- a/Billed-app-FR-Front/src/__tests__/Bills.js
+++ b/Billed-app-FR-Front/src/__tests__/Bills.js
@@ -38,5 +38,25 @@ describe("Given I am connected as an employee", () => {
       const datesSorted = [...dates].sort(antiChrono)
       expect(dates).toEqual(datesSorted)
     })
+    //Permet de tester l'appel d'une fonction lorsque l'utilisateur clique sur le btn
+    test("Then, when I click on the new bill button the page to create a bill is loaded", () => {   
+      Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+      window.localStorage.setItem('user', JSON.stringify({
+        type: 'Employee'
+      }));
+      document.body.innerHTML = BillsUI({ data: bills });
+      const onNavigate = (pathname) => {
+        document.body.innerHTML = ROUTES({ pathname });
+      }
+      const store = null;
+      const newBills = new Bills({
+        document, onNavigate, store, localStorage: window.localStorage
+      });
+      const handleClickNewBill = jest.fn(newBills.handleClickNewBill);
+      const newBillBtn = screen.getByTestId("btn-new-bill"); 
+      newBillBtn.addEventListener('click', handleClickNewBill);
+      userEvent.click(newBillBtn);
+      expect(handleClickNewBill).toHaveBeenCalled();
+    })
   })
 })

--- a/Billed-app-FR-Front/src/__tests__/Bills.js
+++ b/Billed-app-FR-Front/src/__tests__/Bills.js
@@ -39,7 +39,7 @@ describe("Given I am connected as an employee", () => {
       expect(dates).toEqual(datesSorted)
     })
     //Permet de tester l'appel d'une fonction lorsque l'utilisateur clique sur le btn
-    test.only("Then, when I click on the new bill button the page to create a bill is loaded", () => {   
+    test("Then, when I click on the new bill button the page to create a bill is loaded", () => {   
       Object.defineProperty(window, 'localStorage', { value: localStorageMock });
       window.localStorage.setItem('user', JSON.stringify({
         type: 'Employee'

--- a/Billed-app-FR-Front/src/__tests__/Bills.js
+++ b/Billed-app-FR-Front/src/__tests__/Bills.js
@@ -39,7 +39,7 @@ describe("Given I am connected as an employee", () => {
       expect(dates).toEqual(datesSorted)
     })
     //Permet de tester l'appel d'une fonction lorsque l'utilisateur clique sur le btn
-    test("Then, when I click on the new bill button the page to create a bill is loaded", () => {   
+    test.only("Then, when I click on the new bill button the page to create a bill is loaded", () => {   
       Object.defineProperty(window, 'localStorage', { value: localStorageMock });
       window.localStorage.setItem('user', JSON.stringify({
         type: 'Employee'
@@ -57,6 +57,9 @@ describe("Given I am connected as an employee", () => {
       newBillBtn.addEventListener('click', handleClickNewBill);
       userEvent.click(newBillBtn);
       expect(handleClickNewBill).toHaveBeenCalled();
+
+      const form = screen.getByTestId('form-new-bill');
+      expect(form).toBeTruthy();
     })
   })
 })


### PR DESCRIPTION
Ajout du test permettant de tester le comportement attendu lorsque l'utilisateur clique sur le bouton Nouvelle note de frais. La vérification s'effectue ici sur l'appel de la fonction handleClickNewBill().

