### PR TITLE
Tests Unitaires - Bills - EyeIconBtn

### DIFF
--- a/Billed-app-FR-Front/src/__tests__/Bills.js
+++ b/Billed-app-FR-Front/src/__tests__/Bills.js
@@ -61,8 +61,8 @@ describe("Given I am connected as an employee", () => {
       const form = screen.getByTestId('form-new-bill');
       expect(form).toBeTruthy();
     })
-    //Permet de tester l'ouverture de la modale lors d'un clic sur l'icone en forme d'oeil
-    test('Then I click on the icon eye and a modal should open', () => {
+    //Permet de tester l'appel de la fonction permettant de gérer la modale lors d'un clic sur l'icone en forme d'oeil
+    test('Then I click on the icon eye and a function to show the modal should be called', () => {
       Object.defineProperty(window, 'localStorage', { value: localStorageMock });
       window.localStorage.setItem('user', JSON.stringify({
         type: 'Employee'
@@ -87,8 +87,54 @@ describe("Given I am connected as an employee", () => {
       userEvent.click(eyeBtn);
       
       expect(handleClickIconEye).toHaveBeenCalled();
-      const modale = screen.getByTestId('modaleFile');
-      expect(modale).toBeTruthy();
+    })
+    //Permet de tester l'ouverture de la modale lors d'un clic sur l'icone en forme d'oeil
+    test.only('Then I click on the icon eye and a modal should open', async () => {
+      Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+      window.localStorage.setItem('user', JSON.stringify({
+        type: 'Employee'
+      }))
+      document.body.innerHTML = BillsUI({data: bills})
+      const onNavigate = (pathname) => {
+        document.body.innerHTML = ROUTES({ pathname })
+      }
+      const store = null
+      const newBills = new Bills({
+        document, onNavigate, store, bills, localStorage: window.localStorage
+      })
+      
+      //Mock the .modal()
+      $.fn.modal = jest.fn();
+
+      let modale = document.getElementsByClassName('modal-body');
+
+      let value;
+
+      if(typeof modale[0].childNodes[0].childNodes[0] === "undefined")
+      {
+        //S'il n'y a pas de child, alors aucune image n'est affichée dans la modale
+        value = null;
+      }
+      else
+      {
+        value = modale[0].childNodes[0].childNodes[0].src;
+      }
+
+      //Dans un premier temps, la modale doit être vide. Ensuite lorsque l'on clique sur l'icone alors l'image s'affiche.
+      expect(value).toBeNull();
+
+      const handleClickIconEye = newBills.handleClickIconEye
+      const eye = screen.getAllByTestId('icon-eye')
+      eye[1].addEventListener('click', handleClickIconEye(eye[1]))
+      userEvent.click(eye[1])
+
+      modale = document.getElementsByClassName('modal-body');
+      
+      let ExpectFileUrl = "https://test.storage.tld/v0/b/billable-677b6.a…61.jpeg?alt=media&token=7685cd61-c112-42bc-9929-8a799bb82d8b";
+      let uriDecodeTestLink = decodeURI(modale[0].childNodes[0].childNodes[0].src)      
+
+      expect(uriDecodeTestLink).not.toBeNull();
+      expect(uriDecodeTestLink).toBe(ExpectFileUrl);
     })
   })
 })

--- a/Billed-app-FR-Front/src/__tests__/Bills.js
+++ b/Billed-app-FR-Front/src/__tests__/Bills.js
@@ -89,7 +89,7 @@ describe("Given I am connected as an employee", () => {
       expect(handleClickIconEye).toHaveBeenCalled();
     })
     //Permet de tester l'ouverture de la modale lors d'un clic sur l'icone en forme d'oeil
-    test.only('Then I click on the icon eye and a modal should open', async () => {
+    test('Then I click on the icon eye and a modal should open', async () => {
       Object.defineProperty(window, 'localStorage', { value: localStorageMock })
       window.localStorage.setItem('user', JSON.stringify({
         type: 'Employee'
@@ -130,8 +130,8 @@ describe("Given I am connected as an employee", () => {
 
       modale = document.getElementsByClassName('modal-body');
       
-      let ExpectFileUrl = "https://test.storage.tld/v0/b/billable-677b6.a…61.jpeg?alt=media&token=7685cd61-c112-42bc-9929-8a799bb82d8b";
-      let uriDecodeTestLink = decodeURI(modale[0].childNodes[0].childNodes[0].src)      
+      let ExpectFileUrl = "https://test.storage.tld/v0/b/billable-677b6.a…dur.png?alt=media&token=571d34cb-9c8f-430a-af52-66221cae1da3";
+      let uriDecodeTestLink = decodeURI(modale[0].childNodes[0].childNodes[0].src)  
 
       expect(uriDecodeTestLink).not.toBeNull();
       expect(uriDecodeTestLink).toBe(ExpectFileUrl);

--- a/Billed-app-FR-Front/src/__tests__/Bills.js
+++ b/Billed-app-FR-Front/src/__tests__/Bills.js
@@ -61,5 +61,34 @@ describe("Given I am connected as an employee", () => {
       const form = screen.getByTestId('form-new-bill');
       expect(form).toBeTruthy();
     })
+    //Permet de tester l'ouverture de la modale lors d'un clic sur l'icone en forme d'oeil
+    test('Then I click on the icon eye and a modal should open', () => {
+      Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+      window.localStorage.setItem('user', JSON.stringify({
+        type: 'Employee'
+      }));
+      document.body.innerHTML = BillsUI({ data: bills });
+      const onNavigate = (pathname) => {
+        document.body.innerHTML = ROUTES({ pathname });
+      }
+      const store = null;
+      const newBills = new Bills({
+        document, onNavigate, store, localStorage: window.localStorage
+      });
+
+       //Mock the .modal()
+       $.fn.modal = jest.fn();
+
+      const eyeBtn = document.querySelector("#eye");
+      const handleClickIconEye = jest.fn(newBills.handleClickIconEye(eyeBtn));
+      
+      
+      eyeBtn.addEventListener('click', handleClickIconEye);
+      userEvent.click(eyeBtn);
+      
+      expect(handleClickIconEye).toHaveBeenCalled();
+      const modale = screen.getByTestId('modaleFile');
+      expect(modale).toBeTruthy();
+    })
   })
 })

--- a/Billed-app-FR-Front/src/containers/Bills.js
+++ b/Billed-app-FR-Front/src/containers/Bills.js
@@ -34,12 +34,11 @@ export default class {
       .list()
       .then(snapshot => {
         const bills = snapshot
-          .sort((a,b) => new Date(b.date) - new Date(a.date))
           .map(doc => {
             try {
               return {
                 ...doc,
-                date: formatDate(doc.date),
+                //date: formatDate(doc.date),
                 status: formatStatus(doc.status)
               }
             } catch(e) {

--- a/Billed-app-FR-Front/src/containers/NewBill.js
+++ b/Billed-app-FR-Front/src/containers/NewBill.js
@@ -29,12 +29,13 @@ export default class NewBill {
     formData.append('email', email)
 
     //Récupération de l'extention
-    const fileExt = fileName.split(".")[1];
+    const fileType = file['type'].split("/")[0];
+    const fileExt = file['type'].split("/")[1];
 
     //Vérification de l'extension
     const ExtSupported = ["jpg", "jpeg", "png"];
 
-    if(ExtSupported.includes(fileExt))
+    if(ExtSupported.includes(fileExt) && fileType === "image")
     {
       //Attention aux insertions null
       this.store

--- a/Billed-app-FR-Front/src/views/BillsUI.js
+++ b/Billed-app-FR-Front/src/views/BillsUI.js
@@ -26,7 +26,7 @@ const rows = (data) => {
 export default ({ data: bills, loading, error }) => {
   
   const modal = () => (`
-    <div class="modal fade" id="modaleFile" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+    <div class="modal fade" id="modaleFile" data-testid="modaleFile" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
         <div class="modal-content">
           <div class="modal-header">

--- a/Billed-app-FR-Front/src/views/BillsUI.js
+++ b/Billed-app-FR-Front/src/views/BillsUI.js
@@ -20,7 +20,9 @@ const row = (bill) => {
   }
 
 const rows = (data) => {
-  return (data && data.length) ? data.map(bill => row(bill)).join("") : ""
+  return (data && data.length) ? data
+  .sort((a,b) => new Date(b.date) - new Date(a.date))
+  .map(bill => row(bill)).join("") : ""
 }
 
 export default ({ data: bills, loading, error }) => {


### PR DESCRIPTION
Ajout du test permettant de tester le comportement attendu lorsque l'utilisateur clique sur le bouton en forme d'œil. La vérification s'effectue ici sur l'appel de la fonction handleClickIconEye().

Ensuite, le test vérifie que la modale contenant l'image du justificatif apparait à l'écran.