### PR TITLE
Tests unitaires - newBill - icone

### DIFF
--- a/Billed-app-FR-Front/src/__tests__/Bills.js
+++ b/Billed-app-FR-Front/src/__tests__/Bills.js
@@ -64,8 +64,8 @@ describe("Given I am connected as an employee", () => {
       const form = screen.getByTestId('form-new-bill');
       expect(form).toBeTruthy();
     })
-    //Permet de tester l'ouverture de la modale lors d'un clic sur l'icone en forme d'oeil
-    test('Then I click on the icon eye and a modal should open', () => {
+    //Permet de tester l'appel de la fonction permettant de gérer la modale lors d'un clic sur l'icone en forme d'oeil
+    test('Then I click on the icon eye and a function to show the modal should be called', () => {
       Object.defineProperty(window, 'localStorage', { value: localStorageMock });
       window.localStorage.setItem('user', JSON.stringify({
         type: 'Employee'
@@ -79,22 +79,65 @@ describe("Given I am connected as an employee", () => {
         document, onNavigate, store, localStorage: window.localStorage
       });
 
-      //Mock the .modal()
-      $.fn.modal = jest.fn();
-
-      //Vérifie que la modale n'est pas affiché
-      let modale = screen.getByTestId('modaleFile');
-      expect(modale.classList.contains('show')).toBe(false);
+       //Mock the .modal()
+       $.fn.modal = jest.fn();
 
       const eyeBtn = document.querySelector("#eye");
       const handleClickIconEye = jest.fn(newBills.handleClickIconEye(eyeBtn));
+      
       
       eyeBtn.addEventListener('click', handleClickIconEye);
       userEvent.click(eyeBtn);
       
       expect(handleClickIconEye).toHaveBeenCalled();
-      modale = screen.getByTestId('modaleFile');
-      expect(modale).toBeTruthy();
+    })
+    //Permet de tester l'ouverture de la modale lors d'un clic sur l'icone en forme d'oeil
+    test('Then I click on the icon eye and a modal should open', async () => {
+      Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+      window.localStorage.setItem('user', JSON.stringify({
+        type: 'Employee'
+      }))
+      document.body.innerHTML = BillsUI({data: bills})
+      const onNavigate = (pathname) => {
+        document.body.innerHTML = ROUTES({ pathname })
+      }
+      const store = null
+      const newBills = new Bills({
+        document, onNavigate, store, bills, localStorage: window.localStorage
+      })
+      
+      //Mock the .modal()
+      $.fn.modal = jest.fn();
+
+      let modale = document.getElementsByClassName('modal-body');
+
+      let value;
+
+      if(typeof modale[0].childNodes[0].childNodes[0] === "undefined")
+      {
+        //S'il n'y a pas de child, alors aucune image n'est affichée dans la modale
+        value = null;
+      }
+      else
+      {
+        value = modale[0].childNodes[0].childNodes[0].src;
+      }
+
+      //Dans un premier temps, la modale doit être vide. Ensuite lorsque l'on clique sur l'icone alors l'image s'affiche.
+      expect(value).toBeNull();
+
+      const handleClickIconEye = newBills.handleClickIconEye
+      const eye = screen.getAllByTestId('icon-eye')
+      eye[1].addEventListener('click', handleClickIconEye(eye[1]))
+      userEvent.click(eye[1])
+
+      modale = document.getElementsByClassName('modal-body');
+      
+      let ExpectFileUrl = "https://test.storage.tld/v0/b/billable-677b6.a…dur.png?alt=media&token=571d34cb-9c8f-430a-af52-66221cae1da3";
+      let uriDecodeTestLink = decodeURI(modale[0].childNodes[0].childNodes[0].src)  
+
+      expect(uriDecodeTestLink).not.toBeNull();
+      expect(uriDecodeTestLink).toBe(ExpectFileUrl);
     })
   })
 })

--- a/Billed-app-FR-Front/src/__tests__/NewBill.js
+++ b/Billed-app-FR-Front/src/__tests__/NewBill.js
@@ -2,17 +2,34 @@
  * @jest-environment jsdom
  */
 
-import { screen } from "@testing-library/dom"
-import NewBillUI from "../views/NewBillUI.js"
-import NewBill from "../containers/NewBill.js"
+import {screen, waitFor} from "@testing-library/dom";
+import {localStorageMock} from "../__mocks__/localStorage.js";
+import router from "../app/Router.js";
+import { ROUTES, ROUTES_PATH} from "../constants/routes.js";
+import NewBillUI from "../views/NewBillUI.js";
+import NewBill from "../containers/NewBill.js";
 
 
 describe("Given I am connected as an employee", () => {
   describe("When I am on NewBill Page", () => {
-    test("Then ...", () => {
-      const html = NewBillUI()
-      document.body.innerHTML = html
-      //to-do write assertion
+    test("Then new bill icon in vertical layout should be highlighted", async () => {
+      //initialisation
+      Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+      window.localStorage.setItem('user', JSON.stringify({
+        type: 'Employee'
+      }))
+      //html
+      const root = document.createElement("div")
+      root.setAttribute("id", "root")
+      document.body.append(root)
+      //route
+      router()
+      window.onNavigate(ROUTES_PATH.NewBill)
+      //récupération et test
+      await waitFor(() => screen.getByTestId('icon-mail'))
+      const mailIcon = screen.getByTestId('icon-mail')
+      expect(mailIcon).not.toBeNull();
+      expect(mailIcon.classList.contains('active-icon')).toBe(true);
     })
   })
 })


### PR DESCRIPTION
Ajout d'un test permettant de vérifier que l'icone en forme d'enveloppe est mise en avant lorsque l'on clique sur nouvelle note de frais